### PR TITLE
Verify dropdown

### DIFF
--- a/workforceDashboard/src/main/java/gov/homeoffice/workforceDashboard/controller/EmployeeController.java
+++ b/workforceDashboard/src/main/java/gov/homeoffice/workforceDashboard/controller/EmployeeController.java
@@ -97,9 +97,13 @@ public class EmployeeController {
     }
 
     @PostMapping("/seeSelectedViews")
-    public String seeSelectedViews (Model model, HttpServletRequest request) {
+    public String seeSelectedViews (Model model, HttpServletRequest request, RedirectAttributes redirectAttributes) {
         String selection = request.getParameter("selectedOption");
         model.addAttribute("selection", selection);
+        if (selection == null) {
+            redirectAttributes.addFlashAttribute("message", "Please use the dropdown menu above to make a selection.");
+            return "redirect:/selectedViews";
+        }
         employeeService.excelReader();
         model.addAttribute("lists", employeeService.findByUniqueFunction(selection));
         return "functionView";

--- a/workforceDashboard/src/main/resources/templates/selectedViews.html
+++ b/workforceDashboard/src/main/resources/templates/selectedViews.html
@@ -29,11 +29,8 @@
         </table>
         </form>
         <br><td><a href="/fileUploadStatus">Back</a></td>
-
         <div th:if="${message}">
             <h2 th:text="${message}"/>
         </div>
-
-
      </body>
 </html>

--- a/workforceDashboard/src/main/resources/templates/selectedViews.html
+++ b/workforceDashboard/src/main/resources/templates/selectedViews.html
@@ -18,7 +18,7 @@
             <tr>
                 <td>
                     <select class="form-control" name="selectedOption">
-                        <option disabled selected>Filter by workforce Function</option>
+                        <option disabled selected value="promptText">Filter by workforce Function...</option>
                         <option th:each="function : ${functions}"
                                 th:value="${function}"
                                 th:text="${function}">
@@ -29,5 +29,11 @@
         </table>
         </form>
         <br><td><a href="/fileUploadStatus">Back</a></td>
+
+        <div th:if="${message}">
+            <h2 th:text="${message}"/>
+        </div>
+
+
      </body>
 </html>


### PR DESCRIPTION
Added a simple verify function to prevent Null value being selected from drop-down menu if the default text prompt is showing when Select is clicked.